### PR TITLE
Withdraw reasons flag changed in 'pallet_deip_vesting'

### DIFF
--- a/pallets/deip_vesting/src/benchmarking.rs
+++ b/pallets/deip_vesting/src/benchmarking.rs
@@ -24,7 +24,7 @@ fn add_locks<T: Config>(who: &T::AccountId, n: u8) {
     for id in 0..n {
         let lock_id = [id; 8];
         let locked = 100u32;
-        let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
+        let reasons = WithdrawReasons::TRANSACTION_PAYMENT | WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE | WithdrawReasons::FEE | WithdrawReasons::TIP;
         T::Currency::set_lock(lock_id, who, locked.into(), reasons);
     }
 }

--- a/pallets/deip_vesting/src/lib.rs
+++ b/pallets/deip_vesting/src/lib.rs
@@ -170,7 +170,7 @@ pub mod pallet {
                         vesting_during_cliff,
                     },
                 );
-                let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
+                let reasons = WithdrawReasons::TRANSACTION_PAYMENT | WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE | WithdrawReasons::FEE | WithdrawReasons::TIP;
                 T::Currency::set_lock(VESTING_ID, who, total_amount, reasons);
             }
         }
@@ -251,7 +251,7 @@ pub mod pallet {
                 VestingPlans::<T>::remove(&who);
                 Self::deposit_event(Event::<T>::VestingCompleted(who));
             } else {
-                let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
+                let reasons = WithdrawReasons::TRANSACTION_PAYMENT | WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE | WithdrawReasons::FEE | WithdrawReasons::TIP;
                 T::Currency::set_lock(VESTING_ID, &who, locked_now, reasons);
                 Self::deposit_event(Event::<T>::VestingUpdated(who, locked_now));
             }


### PR DESCRIPTION
I listed all flags I found in this doc. We need to keep assets frozen for any kind of action before they will be unlocked according to Vesting Plan